### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix race condition in Spaceship

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-02-20: [Race Condition] Concurrent access to mutable state without synchronization.

--- a/elements/random.go
+++ b/elements/random.go
@@ -21,7 +21,9 @@ func NewRandomColor() allegro.Color {
 	return allegro.MapRGB(byte(rand.Intn(255)), byte(rand.Intn(255)), byte(rand.Intn(255)))
 }
 
-func (s Spaceship) NewBullet() *Bullet {
+func (s *Spaceship) NewBullet() *Bullet {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return &Bullet{
 		Power:    rand.Intn(200),
 		Speed:    float32(rand.Intn(50)),

--- a/elements/spaceship.go
+++ b/elements/spaceship.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lucasew/allegro_blasteroids_go/point"
 	"github.com/lucasew/golog"
 	"math"
+	"sync"
 )
 
 var slog = golog.Default.NewLogger("spaceship")
@@ -17,45 +18,62 @@ type Spaceship struct {
 	Health   int
 	Speed    float32
 	Position *point.HeadedPoint
+	mu       sync.Mutex
 }
 
-func (a Spaceship) Color() allegro.Color {
+func (a *Spaceship) Color() allegro.Color {
 	return allegro.MapRGB(255, 255, 0)
 }
 
 func (a *Spaceship) Tick(tick float32, w, h int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.Position.FixPosition(w, h)
 }
 
 func (a *Spaceship) MoveAhead() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.Position.GoAhead(a.Speed)
 }
 
 func (a *Spaceship) MoveReverse() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.Position.GoAhead(-a.Speed)
 }
 
 func (a *Spaceship) TurnLeft() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.Position.Turn(-headingStep)
 }
 
 func (a *Spaceship) TurnRight() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.Position.Turn(headingStep)
 }
 
-func (a Spaceship) ToString() string {
+func (a *Spaceship) ToString() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return fmt.Sprintf("Spaceship(%.2f px/s + %d %s)", a.Speed, a.Health, a.Position.ToString())
 }
 
-func (a Spaceship) GetPosition() point.Point {
+func (a *Spaceship) GetPosition() point.Point {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return point.Point{
 		X: a.Position.X,
 		Y: a.Position.Y,
 	}
 }
 
-func (a Spaceship) Draw() {
+func (a *Spaceship) Draw() {
 	slog.Info("draw")
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	var t allegro.Transform
 	t.Identity()
 	t.Rotate(a.Position.Heading.Heading)
@@ -67,15 +85,19 @@ func (a Spaceship) Draw() {
 	primitives.DrawLine(primitives.Point{X: 6, Y: 4}, primitives.Point{X: 1, Y: 4}, a.Color(), 2)
 }
 
-func (a Spaceship) DangerRadius() float32 {
+func (a *Spaceship) DangerRadius() float32 {
 	return 10
 }
 
-func (a Spaceship) IsDead() bool {
+func (a *Spaceship) IsDead() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.Health <= 0
 }
 
 func (a *Spaceship) Hurt(howmuch int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if howmuch > 2 {
 		howmuch = 0 // Não levar dano das próprias bullets
 	}
@@ -83,12 +105,14 @@ func (a *Spaceship) Hurt(howmuch int) {
 	a.Health -= howmuch
 }
 
-func (a Spaceship) GetPower() int {
+func (a *Spaceship) GetPower() int {
 	return 1
 }
 
-func (a Spaceship) GetLife() int {
+func (a *Spaceship) GetLife() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.Health
 }
 
-func (a Spaceship) Die() {}
+func (a *Spaceship) Die() {}

--- a/elements/spaceship_test.go
+++ b/elements/spaceship_test.go
@@ -1,0 +1,34 @@
+package elements
+
+import (
+	"testing"
+	"github.com/lucasew/allegro_blasteroids_go/point"
+    "sync"
+)
+
+func TestSpaceshipRace(t *testing.T) {
+	spaceship := &Spaceship{
+		Health:   100,
+		Speed:    20,
+		Position: point.NewHeadedPoint(40, 40, 1),
+	}
+
+    var wg sync.WaitGroup
+    wg.Add(2)
+
+    go func() {
+        defer wg.Done()
+        for i := 0; i < 1000; i++ {
+            spaceship.MoveAhead()
+        }
+    }()
+
+    go func() {
+        defer wg.Done()
+        for i := 0; i < 1000; i++ {
+             _ = spaceship.GetPosition()
+        }
+    }()
+
+    wg.Wait()
+}


### PR DESCRIPTION
## Severity: Critical
## Vulnerability: Race Condition

### Impact
Concurrent access to the `Spaceship` instance from the input handling goroutine (`handleEvents`) and the main game loop (`App`) causes a data race. Methods like `TurnLeft` modify `Position` (specifically `Heading`) while `GetPosition` (called via collision detection) reads it. This can lead to undefined behavior, crashes, or glitches.

### Fix
- Added `sync.Mutex` to `Spaceship` struct.
- Changed all `Spaceship` methods to use pointer receivers `(a *Spaceship)` to prevent lock copying and ensure state is shared correctly.
- Added `Lock()` and `Unlock()` to all methods accessing or modifying `Spaceship` state.
- Updated `NewBullet` in `elements/random.go` to use pointer receiver and lock.
- Added a permanent regression test `TestSpaceshipRace` in `elements/spaceship_test.go` to verify thread safety.

### Verification
- Created a reproduction test case that consistently triggered the race condition with `go test -race`.
- Applied the fix.
- Verified that `go test -race` passes with the fix.

---
*PR created automatically by Jules for task [5886569191003760188](https://jules.google.com/task/5886569191003760188) started by @lucasew*